### PR TITLE
Fix Ladder Range Rows

### DIFF
--- a/ladder/ladder.js
+++ b/ladder/ladder.js
@@ -167,6 +167,6 @@ function updateLadder() {
   const vectors = summoners.map(({ rank, opggLink, summonerName, discordName, studentStatus, preferredRoles }) => [toRankString(rank), toLpString(rank), toSummonerNameString(summonerName), opggLink, discordName, studentStatus, preferredRoles]);
 
   if (!vectors.length) return;
-  ladderSheet.getRange(2, 1, ladderSheet.getMaxRows(), ladderSheet.getMaxColumns() - 1).clearContent();
+  ladderSheet.getRange(2, 1, ladderSheet.getMaxRows() - 1, ladderSheet.getMaxColumns() - 1).clearContent();
   ladderSheet.getRange(2, 1, vectors.length, ladderSheet.getMaxColumns() - 1).setValues(vectors);
 }


### PR DESCRIPTION
- Fixes an off-by-one error in the number of rows in `getRange()`.
- This caused the Ladder sheet to grow by one row on every invocation of `updateLadder()`.
- This eventually caused the History spreadsheet to stop working.
- The History spreadsheet could no longer copy from the Ladder sheet because of the 5 million cell limitation for a single spreadsheet.